### PR TITLE
Remove unused import which caused load failed

### DIFF
--- a/src/plugins/ELF_RSS2/__init__.py
+++ b/src/plugins/ELF_RSS2/__init__.py
@@ -2,9 +2,7 @@ from pathlib import Path
 
 import nonebot
 
-from bot import config
 from .config import Config
-# from .plugins import RSSHUB
 
 global_config = nonebot.get_driver().config
 plugin_config = Config(**global_config.dict())


### PR DESCRIPTION
This will cause load plugin failed when working directory is not under current path