### PR TITLE
增加对 GIF 图片的处理；修改图片缩放基准

### DIFF
--- a/src/plugins/ELF_RSS2/RSS/rss_class.py
+++ b/src/plugins/ELF_RSS2/RSS/rss_class.py
@@ -63,7 +63,7 @@ class rss:
 
     # 返回订阅链接
     def geturl(self, rsshub: str = config.rsshub) -> str:
-        if re.match(u'[hH][tT]{2}[pP][sS]{0,}://', self.url, flags=0):
+        if re.match(u'[hH][tT]{2}[pP][sS]?://', self.url, flags=0):
             return self.url
         else:
             # 先判断地址是否 / 开头


### PR DESCRIPTION
现在GIF图片也能得到处理了，不过暂时先把分辨率上限限制为 300 x 300 了。

原来的缩放临界值，现在改为图片长度最大值。

原来的处理方式存在问题：如果图片大小刚好没超过缩放临界值的2倍，会被截断取整为1，
此时的缩放比例为1。
因为 Image.thumbnail() 对 JPEG 与 PNG 处理后的效果不同， PNG 是无损压缩，导致有时候处理后的 PNG 文件反而比源文件体积更大。
比如缩放没改变分辨率的情况下，也就是缩放比例为1，此时 JPEG 通常压缩效果很明显，而 PNG 就不一定了。

虽然能去掉截断取整，通过其他方式来得到新的缩放后分辨率，但是我认为不如直接设置一个最大分辨率为基准，这样最终超出基准被缩放的图片，个体间的分辨率差距不会太大。

此外，即使源文件的分辨率低于缩放基准，也会得到压缩处理，最终发出的图片体积会缩小（除了上面提到的少数极端情况）。 Image.thumbnail() 只会以 size 为基准按源文件等比例缩小，不会放大图片。

另外我忘了在 commit 信息里说明：
通过 Image.format 能等到图片的真实文件类型，不需要拿 content-type ，同时能避免 content-type 与真实文件类型不同的情况。