### PR TITLE
订阅参数增加 `仅含有图片` 设置项

### DIFF
--- a/src/plugins/ELF_RSS2/RSS/rss_class.py
+++ b/src/plugins/ELF_RSS2/RSS/rss_class.py
@@ -24,6 +24,7 @@ class Rss:
     translation = False  # 翻译
     only_title = False  # 仅标题
     only_pic = False  # 仅图片
+    only_has_pic = False  # 仅含有图片
     cookies = ""
     down_torrent: bool = False  # 是否下载种子
     down_torrent_keyword: str = None  # 过滤关键字，支持正则
@@ -43,6 +44,7 @@ class Rss:
         translation=False,
         only_title=False,
         only_pic=False,
+        only_has_pic=False,
         cookies: str = "",
         down_torrent: bool = False,
         down_torrent_keyword: str = None,
@@ -66,6 +68,7 @@ class Rss:
         self.translation = translation
         self.only_title = only_title
         self.only_pic = only_pic
+        self.only_has_pic = only_has_pic
         if len(cookies) <= 0 or cookies is None:
             self.cookies = None
         else:
@@ -276,6 +279,7 @@ class Rss:
             f"翻译：{self.translation}\n"
             f"仅标题：{self.only_title}\n"
             f"仅图片：{self.only_pic}\n"
+            f"仅含有图片：{self.only_has_pic}\n"
             f"下载种子：{self.down_torrent}\n"
             f"白名单关键词：{self.down_torrent_keyword}\n"
             f"黑名单关键词：{self.black_keyword}{cookies_str}{down_msg}\n"

--- a/src/plugins/ELF_RSS2/RSS/rss_parsing.py
+++ b/src/plugins/ELF_RSS2/RSS/rss_parsing.py
@@ -123,8 +123,10 @@ async def start(rss: rss_class.Rss) -> None:
             write_item(rss=rss, new_rss=new_rss, new_item=item)
             continue
         # 检查是否只推送有图片的消息
-        if rss.only_pic and not re.search("<img.+?>", item["summary"]):
-            logger.info("已开启仅图片，该消息没有图片，将跳过")
+        if (rss.only_pic or rss.only_has_pic) and not re.search(
+            r"<img.+?>|\[img]", item["summary"]
+        ):
+            logger.info(f"{rss.name} 已开启仅图片/仅含有图片，该消息没有图片，将跳过")
             write_item(rss=rss, new_rss=new_rss, new_item=item)
             continue
 

--- a/src/plugins/ELF_RSS2/RSS/rss_parsing.py
+++ b/src/plugins/ELF_RSS2/RSS/rss_parsing.py
@@ -620,7 +620,7 @@ async def handle_html_tag(html, translation: bool) -> str:
     rss_str = re.sub(r"(\[.*?=.*?])|(\[/.*?])", "", rss_str)
 
     # 处理一些 HTML 标签
-    rss_str = re.sub("<br/><br/>|<br><br>|<br>|<br/>", "\n", rss_str)
+    rss_str = re.sub("<br ?/?><br ?/?>|<br ?/?>|<hr ?/?>", "\n", rss_str)
     rss_str = re.sub('<span>|<span .+?">|</span>', "", rss_str)
     rss_str = re.sub('<pre .+?">|</pre>', "", rss_str)
     rss_str = re.sub('<p>|<p .+?">|</p>|<b>|<b .+?">|</b>', "", rss_str)
@@ -629,6 +629,7 @@ async def handle_html_tag(html, translation: bool) -> str:
     rss_str = re.sub('<iframe .+?"/>', "", rss_str)
     rss_str = re.sub('<i .+?">|<i>|</i>', "", rss_str)
     rss_str = re.sub("<code>|</code>|<ul>|</ul>", "", rss_str)
+    rss_str = re.sub('<font .+?">|</font>', "", rss_str)
     # 解决 issue #3
     rss_str = re.sub('<dd .+?">|<dd>|</dd>', "", rss_str)
     rss_str = re.sub('<dl .+?">|<dl>|</dl>', "", rss_str)

--- a/src/plugins/ELF_RSS2/change_dy.py
+++ b/src/plugins/ELF_RSS2/change_dy.py
@@ -34,12 +34,13 @@ async def handle_first_receive(bot: Bot, event: Event, state: dict):
             "\ntest qq=,123,234 qun=-1"
             "\n对应参数:"
             "\n订阅链接-url QQ-qq 群-qun 更新频率-time"
-            "\n代理-proxy 翻译-tl 仅title-ot，仅图片-op"
+            "\n代理-proxy 翻译-tl 仅title-ot，仅图片-op，仅含有图片-ohp"
             "\n下载种子-downopen 白名单关键词-wkey 黑名单关键词-bkey 种子上传到群-upgroup"
             "\n去重模式-mode"
             "\n图片数量限制-img_num 最多一条消息只会发送指定数量的图片，防止刷屏"
             "\n注："
-            "\nproxy、tl、ot、op、downopen、upgroup 值为 1/0"
+            "\n仅含有图片不同于仅图片，除了图片还会发送正文中的其他文本信息"
+            "\nproxy、tl、ot、op、ohp、downopen、upgroup 值为 1/0"
             "\n去重模式分为按链接(link)、标题(title)、图片(image)判断"
             "\n其中 image 模式,出于性能考虑以及避免误伤情况发生,生效对象限定为只带 1 张图片的消息,"
             "\n此外,如果属性中带有 or 说明判断逻辑是任一匹配即去重,默认为全匹配"
@@ -74,6 +75,7 @@ attribute_dict = {
     "tl": "translation",
     "ot": "only_title",
     "op": "only_pic",
+    "ohp": "only_has_pic",
     "upgroup": "is_open_upload_group",
     "downopen": "down_torrent",
     "downkey": "down_torrent_keyword",
@@ -102,7 +104,7 @@ def handle_change_list(
                 value_to_change = "1"
             else:
                 value_to_change = str(int(float(value_to_change)))
-    elif key_to_change in ["proxy", "tl", "ot", "op", "upgroup", "downopen"]:
+    elif key_to_change in ["proxy", "tl", "ot", "op", "ohp", "upgroup", "downopen"]:
         value_to_change = bool(int(value_to_change))
     elif (
         key_to_change in ["downkey", "wkey", "blackkey", "bkey"]


### PR DESCRIPTION
- 满足 `过滤不带图片的消息` 同时 `想要正文中的其他文本信息` 这一情景
- 进行过滤判断的时候加上对Markdown标签的判断，日志信息里加上当前订阅的名称