### PR TITLE
修正 `<a> 标签处理` 的逻辑（又遇到 `outer_html()` 的坑）

### DIFF
--- a/src/plugins/ELF_RSS2/RSS/rss_parsing.py
+++ b/src/plugins/ELF_RSS2/RSS/rss_parsing.py
@@ -658,13 +658,12 @@ async def handle_html_tag(html, translation: bool) -> str:
 
     # <a> 标签处理
     for a in html("a").items():
+        a_str = re.search(r"<a.+?</a>", str(a))[0]
         if str(a.text()) != a.attr("href"):
-            rss_str = rss_str.replace(
-                a.outer_html(), f" {a.text()}: {a.attr('href')}\n"
-            )
+            rss_str = rss_str.replace(a_str, f" {a.text()}: {a.attr('href')}\n")
         else:
-            rss_str = rss_str.replace(a.outer_html(), f" {a.attr('href')}\n")
-        rss_str_tl = rss_str_tl.replace(a.outer_html(), "")
+            rss_str = rss_str.replace(a_str, f" {a.attr('href')}\n")
+        rss_str_tl = rss_str_tl.replace(a_str, "")
 
     # 处理一些 HTML 标签
     rss_str = re.sub('<br .+?"/>|<(br|hr) ?/?>', "\n", rss_str)


### PR DESCRIPTION
`outer_html()` 对 `<a> 标签` 的 `href` 属性再做了一次转义，导致有些情况下无法正确处理 `<a> 标签`。