### PR TITLE
修正 `获取图像指纹时格式为 GIF` 时的逻辑，修正 `去除多余换行` 的逻辑

### DIFF
--- a/src/plugins/ELF_RSS2/RSS/rss_parsing.py
+++ b/src/plugins/ELF_RSS2/RSS/rss_parsing.py
@@ -256,6 +256,9 @@ async def duplicate_exists(
                 continue
             im = Image.open(BytesIO(content))
             image_hash = imagehash.average_hash(im)
+            # GIF 图片的 image_hash 实际上是第一帧的值，为了避免误伤加个后缀来区分
+            if im.format == "GIF":
+                image_hash += ".GIF"
             logger.info(f"image_hash: {image_hash}")
             sql += f" AND image_hash='{image_hash}'"
         if mode == "link":

--- a/src/plugins/ELF_RSS2/RSS/rss_parsing.py
+++ b/src/plugins/ELF_RSS2/RSS/rss_parsing.py
@@ -258,7 +258,7 @@ async def duplicate_exists(
             image_hash = imagehash.average_hash(im)
             # GIF 图片的 image_hash 实际上是第一帧的值，为了避免误伤加个后缀来区分
             if im.format == "GIF":
-                image_hash += ".GIF"
+                image_hash += ".gif"
             logger.info(f"image_hash: {image_hash}")
             sql += f" AND image_hash='{image_hash}'"
         if mode == "link":

--- a/src/plugins/ELF_RSS2/RSS/rss_parsing.py
+++ b/src/plugins/ELF_RSS2/RSS/rss_parsing.py
@@ -256,9 +256,9 @@ async def duplicate_exists(
                 continue
             im = Image.open(BytesIO(content))
             image_hash = imagehash.average_hash(im)
-            # GIF 图片的 image_hash 实际上是第一帧的值，为了避免误伤加个后缀来区分
+            # GIF 图片的 image_hash 实际上是第一帧的值，为了避免误伤直接跳过
             if im.format == "GIF":
-                image_hash += ".gif"
+                continue
             logger.info(f"image_hash: {image_hash}")
             sql += f" AND image_hash='{image_hash}'"
         if mode == "link":

--- a/src/plugins/ELF_RSS2/RSS/rss_parsing.py
+++ b/src/plugins/ELF_RSS2/RSS/rss_parsing.py
@@ -688,10 +688,10 @@ async def handle_html_tag(html, translation: bool) -> str:
     # 删除图片、视频标签
     rss_str = re.sub(r'<video .+?"?/>|</video>|<img.+?>', "", rss_str)
 
-    # 去掉换行
+    # 去掉多余换行
     while re.search("\n\n", rss_str) or re.search("\n\n", rss_str_tl):
-        rss_str = re.sub("\n\n", "", rss_str)
-        rss_str_tl = re.sub("\n\n", "", rss_str_tl)
+        rss_str = re.sub("\n\n", "\n", rss_str)
+        rss_str_tl = re.sub("\n\n", "\n", rss_str_tl)
 
     if 0 < config.max_length < len(rss_str):
         rss_str = rss_str[: config.max_length] + "..."

--- a/src/plugins/ELF_RSS2/start.py
+++ b/src/plugins/ELF_RSS2/start.py
@@ -55,5 +55,5 @@ start_metaevent = on_metaevent(rule=check_first_connect, block=True)
 
 @start_metaevent.handle()
 async def _(bot: Bot, event: Event, state: dict):
-    """启动时发送启动成功信息"""
+    # 启动时发送启动成功信息
     await start()


### PR DESCRIPTION
GIF 图片的 `image_hash` 实际上是第一帧的值，为了避免误伤跳过