### PR TITLE
修正 `dict_hash()` 中过滤 `summary` 字段时的逻辑，先判断是否存在，避免 KeyError

### DIFF
--- a/src/plugins/ELF_RSS2/RSS/rss_parsing.py
+++ b/src/plugins/ELF_RSS2/RSS/rss_parsing.py
@@ -794,7 +794,8 @@ def dict_hash(dictionary: Dict[str, Any]) -> str:
     if dictionary.get("published_parsed"):
         dictionary_temp.pop("published_parsed")
     # 某些情况下，如微博带视频的消息，正文可能不一样，先过滤
-    dictionary_temp.pop("summary")
+    if dictionary.get("summary"):
+        dictionary_temp.pop("summary")
     if dictionary.get("summary_detail"):
         dictionary_temp.pop("summary_detail")
     d_hash = hashlib.md5()


### PR DESCRIPTION
没想到某些时候会缺失 `summary` 字段，概率非常低