### PR TITLE
Version v2.2.9

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,2 @@
 ENVIRONMENT=prod
-VERSION='v2.2.8'
+VERSION='v2.2.9'

--- a/.env.dev
+++ b/.env.dev
@@ -26,9 +26,6 @@ BAIDU_KEY=""
 # 百度翻译接口appid和secretKey，前往http://api.fanyi.baidu.com/获取
 # 一般来说申请标准版免费就够了，想要好一点可以认证上高级版，有月限额，rss用也足够了
 
-# 解决pixiv.cat无法访问问题
-CLOSE_PIXIV_CAT=false  # 是否关闭使用 pixiv.cat，关闭后注意启动代理
-
 # 如果你是Linux部署的，请开启此项
 IS_LINUX=false
 

--- a/docs/常见问题.md
+++ b/docs/常见问题.md
@@ -6,4 +6,5 @@
 
 2. pixiv 图片下载失败，可能是 pixiv.cat 访问不稳定或者频繁拉取导致IP被关小黑屋？
 
-> 出现该情况，将配置文件中 `CLOSE_PIXIV_CAT=True` 该项设置为True。或者换个IP？
+> 注：v2.2.9 开始会自动处理，配置项 `CLOSE_PIXIV_CAT` 失效。
+> 出现该情况，将配置文件中配置项 `CLOSE_PIXIV_CAT` 的值设置为 `true` 。或者换个IP？

--- a/src/plugins/ELF_RSS2/config.py
+++ b/src/plugins/ELF_RSS2/config.py
@@ -28,8 +28,6 @@ class ELFConfig(BaseConfig):
 
     is_linux: bool = os.name != "nt"
 
-    close_pixiv_cat: bool = False
-
     is_open_auto_down_torrent: bool = False
     qb_web_url: str = "http://127.0.0.1:8081"
     qb_down_path: str = ""  # qb的文件下载地址，这个地址必须是 go-cqhttp能访问到的


### PR DESCRIPTION
♻ Refactor code.

- 去除微博话题对应链接，只保留文本

✨ Introduce new features.

- 为 `show_all` 增加关键词过滤功能，同时优化 `show` 与 `show_all` 返回的订阅信息格式

🐛 Bug fixes.

- 去除删除订阅后更新 `rss.json` 时多余的转义

- 修正在群里不带参数使用 `show` 时，遇到订阅中有非群订阅时，因没判空导致代码执行中断

- 修正一个日志打印等级

- 修正 `fuck_pixiv_cat()` 的处理逻辑，同时将调用逻辑改为仅在图片下载失败时及图片地址包含 `pixiv.cat` 时

- 针对如 `Bilibili 直播间开播` 这类内容可能为空的订阅，修正 `get_rss()` `check_update()` 的处理逻辑

📝️ Update docs.

🔧️ Update config files.
