### PR TITLE
V2.4.1

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,2 @@
 ENVIRONMENT=prod
-VERSION='v2.4.0'
+VERSION='v2.4.1'

--- a/docs/2.0 使用教程.md
+++ b/docs/2.0 使用教程.md
@@ -38,7 +38,7 @@
 
 ## 所有订阅
 
-> 命令：showall（所有订阅、selectall）
+> 命令：show_all（showall，select_all，selectall，所有订阅）
 >
 > 参数：[关键词]（支持正则，过滤生效范围：订阅名、订阅地址、QQ号、群号）
 >
@@ -67,15 +67,16 @@
 
 > 命令：change（修改订阅，moddy）
 >
-> 参数：订阅名 属性=值 [[属性=值]...]
+> 参数：订阅名[,订阅名,...] 属性=值[ 属性=值 ...]
 >
-> 示例： `change test qq=, 123, 234 ot=1`
+> 示例： `change test1[,test2,...] qq=,123,234 qun=-1`
 >
 > 使用技巧：可以先只发送 `change` ，机器人会返回提示信息，无需记住复杂的参数列表
 >
 > 对应参数:
 >
-> 订阅名-name 订阅链接-url QQ-qq 群-qun 更新频率-time
+> 订阅名-name 禁止将多个订阅批量改名，会因为名称相同起冲突
+> 订阅链接-url QQ-qq 群-qun 更新频率-time
 > 代理-proxy 翻译-tl 仅title-ot，仅图片-op，仅含有图片-ohp
 > 下载种子-downopen 白名单关键词-wkey 黑名单关键词-bkey 种子上传到群-upgroup
 > 去重模式-mode

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ELF_RSS"
-version = "2.4.0"
+version = "2.4.1"
 description = "ELF_RSS"
 authors = ["Quan666"]
 license = "GPL v3"

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r", encoding="UTF-8") as fh:
 
 setuptools.setup(
     name="ELF_RSS",
-    version="2.4.0",
+    version="2.4.1",
     author="Quan666",
     author_email="i@oy.mk",
     description="QQ机器人 RSS订阅 插件，订阅源建议选择 RSSHub",

--- a/src/plugins/ELF_RSS2/RSS/routes/Parsing/__init__.py
+++ b/src/plugins/ELF_RSS2/RSS/routes/Parsing/__init__.py
@@ -1,7 +1,6 @@
 import difflib
 import re
 import sqlite3
-import time
 
 from nonebot import logger
 from pyquery import PyQuery as Pq
@@ -19,6 +18,7 @@ from .cache_manage import (
     insert_into_cache_db,
 )
 from .cache_manage import cache_filter
+from .handle_date import handle_date as hd
 from .handle_html_tag import handle_bbcode
 from .handle_html_tag import handle_html_tag
 from .handle_images import handle_img
@@ -495,20 +495,8 @@ async def handle_torrent(
 async def handle_date(
     rss: Rss, state: dict, item: dict, item_msg: str, tmp: str, tmp_state: dict
 ) -> str:
-    date = tuple(
-        item.get("updated_parsed")
-        if item.get("updated_parsed")
-        else item.get("published_parsed")
-    )
-    if date:
-        rss_time = time.mktime(date)
-        # 时差处理，待改进
-        if rss_time + 28800.0 <= time.time():
-            rss_time += 28800.0
-        return "日期：" + time.strftime("%m月%d日 %H:%M:%S", time.localtime(rss_time))
-    # 没有日期的情况，以当前时间
-    else:
-        return "日期：" + time.strftime("%m月%d日 %H:%M:%S", time.localtime())
+    date = tuple(item.get("published_parsed", item.get("updated_parsed")))
+    return await hd(date)
 
 
 # 发送消息

--- a/src/plugins/ELF_RSS2/RSS/routes/Parsing/check_update.py
+++ b/src/plugins/ELF_RSS2/RSS/routes/Parsing/check_update.py
@@ -1,23 +1,9 @@
 import hashlib
-import time
 
 from tinydb import TinyDB, Query
 from typing import Dict, Any
 
-
-# 处理日期
-async def handle_date(date=None) -> str:
-    if date:
-        if not isinstance(date, tuple):
-            date = tuple(date)
-        rss_time = time.mktime(date)
-        # 时差处理，待改进
-        if rss_time + 28800.0 < time.time():
-            rss_time += 28800.0
-        return "日期：" + time.strftime("%m月%d日 %H:%M:%S", time.localtime(rss_time))
-    # 没有日期的情况，以当前时间
-    else:
-        return "日期：" + time.strftime("%m月%d日 %H:%M:%S", time.localtime())
+from .handle_date import handle_date
 
 
 # 对 dict 对象计算哈希值，供后续比较
@@ -48,12 +34,10 @@ async def check_update(db: TinyDB, new: list) -> list:
 
     # 对结果按照发布时间排序
     result_with_date = [
-        (await handle_date(i.get("updated_parsed")), i)
-        if i.get("updated_parsed")
-        else (await handle_date(i.get("published_parsed")), i)
+        (await handle_date(i.get("published_parsed", i.get("published_parsed"))), i)
         for i in to_send_list
     ]
-    result_with_date.sort(key=lambda tup: tup[0])
+    result_with_date.sort()
     result = [i for key, i in result_with_date]
 
     return result

--- a/src/plugins/ELF_RSS2/RSS/routes/Parsing/check_update.py
+++ b/src/plugins/ELF_RSS2/RSS/routes/Parsing/check_update.py
@@ -1,9 +1,8 @@
 import hashlib
+import time
 
 from tinydb import TinyDB, Query
 from typing import Dict, Any
-
-from .handle_date import handle_date
 
 
 # 对 dict 对象计算哈希值，供后续比较
@@ -33,11 +32,13 @@ async def check_update(db: TinyDB, new: list) -> list:
             to_send_list.append(i)
 
     # 对结果按照发布时间排序
-    result_with_date = [
-        (await handle_date(i.get("published_parsed", i.get("published_parsed"))), i)
-        for i in to_send_list
-    ]
-    result_with_date.sort()
-    result = [i for key, i in result_with_date]
+    to_send_list.sort(key=get_item_timestamp)
 
-    return result
+    return to_send_list
+
+
+def get_item_timestamp(item: dict) -> float:
+    date = item.get("published_parsed", item.get("updated_parsed"))
+    if not isinstance(date, tuple):
+        date = tuple(date)
+    return time.mktime(date)

--- a/src/plugins/ELF_RSS2/RSS/routes/Parsing/handle_date.py
+++ b/src/plugins/ELF_RSS2/RSS/routes/Parsing/handle_date.py
@@ -1,0 +1,16 @@
+import time
+
+
+# 处理日期
+async def handle_date(date=None) -> str:
+    if date:
+        if not isinstance(date, tuple):
+            date = tuple(date)
+        rss_time = time.mktime(date)
+        # 时差处理，待改进
+        if rss_time + 28800.0 < time.time():
+            rss_time += 28800.0
+        return "日期：" + time.strftime("%m月%d日 %H:%M:%S", time.localtime(rss_time))
+    # 没有日期的情况，以当前时间
+    else:
+        return "日期：" + time.strftime("%m月%d日 %H:%M:%S", time.localtime())

--- a/src/plugins/ELF_RSS2/RSS/rss_class.py
+++ b/src/plugins/ELF_RSS2/RSS/rss_class.py
@@ -22,13 +22,13 @@ class Rss:
         self.only_pic = False  # 仅图片
         self.only_has_pic = False  # 仅含有图片
         self.cookies = ""
-        self.down_torrent: bool = False  # 是否下载种子
-        self.down_torrent_keyword: str = ""  # 过滤关键字，支持正则
-        self.black_keyword: str = ""  # 黑名单关键词
-        self.is_open_upload_group: bool = True  # 默认开启上传到群
-        self.duplicate_filter_mode: [str] = None  # 去重模式
-        self.max_image_number: int = 0  # 图片数量限制，防止消息太长刷屏
-        self.content_to_remove: [str] = None  # 正文待移除内容，支持正则
+        self.down_torrent = False  # 是否下载种子
+        self.down_torrent_keyword = ""  # 过滤关键字，支持正则
+        self.black_keyword = ""  # 黑名单关键词
+        self.is_open_upload_group = True  # 默认开启上传到群
+        self.duplicate_filter_mode = None  # 去重模式
+        self.max_image_number = 0  # 图片数量限制，防止消息太长刷屏
+        self.content_to_remove = None  # 正文待移除内容，支持正则
         self.stop = False  # 停止更新
 
     # 返回订阅链接
@@ -123,7 +123,8 @@ class Rss:
     # 重命名订阅缓存 json 文件
     def rename_file(self, target: str):
         this_file_path = DATA_PATH / (self.name + ".json")
-        this_file_path.rename(target)
+        if Path.exists(this_file_path):
+            this_file_path.rename(target)
 
     # 删除订阅缓存 json 文件
     def delete_file(self):

--- a/src/plugins/ELF_RSS2/add_cookies.py
+++ b/src/plugins/ELF_RSS2/add_cookies.py
@@ -22,22 +22,19 @@ async def handle_first_receive(bot: Bot, event: Event, state: dict):
         state["ADD_COOKIES"] = unescape(args)  # 如果用户发送了参数则直接赋值
 
 
-# 如果只有名称就把该 名称订阅 订阅到当前账号或群组
-
-
-@ADD_COOKIES.got(
-    "ADD_COOKIES",
-    prompt=(
-        "请输入：\n"
-        "名称 cookies\n"
-        "空格分割\n"
-        "获取方式：\n"
-        "PC端 chrome 浏览器按 F12\n"
-        "找到Console选项卡，输入:\n"
-        "document.cookie\n"
-        "输出的字符串就是了"
-    ),
+prompt = (
+    "请输入：\n"
+    "名称 cookies\n"
+    "空格分割\n"
+    "获取方式：\n"
+    "PC端 chrome 浏览器按 F12\n"
+    "找到Console选项卡，输入:\n"
+    "document.cookie\n"
+    "输出的字符串就是了"
 )
+
+
+@ADD_COOKIES.got("ADD_COOKIES", prompt=prompt)
 async def handle_add_cookies(bot: Bot, event: Event, state: dict):
     rss_cookies = unescape(state["ADD_COOKIES"])
 

--- a/src/plugins/ELF_RSS2/change_dy.py
+++ b/src/plugins/ELF_RSS2/change_dy.py
@@ -8,6 +8,7 @@ from nonebot.adapters.cqhttp import Bot, Event, GroupMessageEvent, permission, u
 from nonebot.log import logger
 from nonebot.rule import to_me
 from tinydb import TinyDB, Query
+from typing import List
 
 from .RSS import my_trigger as tr
 from .RSS import rss_class
@@ -29,35 +30,6 @@ async def handle_first_receive(bot: Bot, event: Event, state: dict):
     args = str(event.get_message()).strip()
     if args:
         state["RSS_CHANGE"] = unescape(args)  # 如果用户发送了参数则直接赋值
-    else:
-        await RSS_CHANGE.send(
-            "请输入要修改的订阅"
-            "\n订阅名 属性=值"
-            "\n如:"
-            "\ntest qq=,123,234 qun=-1"
-            "\n对应参数:"
-            "\n订阅名-name 订阅链接-url QQ-qq 群-qun 更新频率-time"
-            "\n代理-proxy 翻译-tl 仅title-ot，仅图片-op，仅含有图片-ohp"
-            "\n下载种子-downopen 白名单关键词-wkey 黑名单关键词-bkey 种子上传到群-upgroup"
-            "\n去重模式-mode"
-            "\n图片数量限制-img_num 只发送限定数量的图片，防止刷屏"
-            "\n正文待移除内容-rm_list 从正文中要移除的指定内容，支持正则"
-            "\n停止更新-stop"
-            "\n注："
-            "\n仅含有图片不同于仅图片，除了图片还会发送正文中的其他文本信息"
-            "\nproxy、tl、ot、op、ohp、downopen、upgroup、stop 值为 1/0"
-            "\n去重模式分为按链接(link)、标题(title)、图片(image)判断"
-            "\n其中 image 模式,出于性能考虑以及避免误伤情况发生,生效对象限定为只带 1 张图片的消息,"
-            "\n此外,如果属性中带有 or 说明判断逻辑是任一匹配即去重,默认为全匹配"
-            "\n白名单关键词支持正则表达式，匹配时推送消息及下载，设为空(wkey=)时不生效"
-            "\n黑名单关键词同白名单一样，只是匹配时不推送，两者可以一起用"
-            "\n正文待移除内容因为参数解析的缘故，格式必须如：rm_list='a' 或 rm_list='a','b'"
-            "\n该处理过程是在解析 html 标签后进行的"
-            "\n要将该参数设为空使用 rm_list='-1'"
-            "\nQQ、群号、去重模式前加英文逗号表示追加,-1设为空"
-            "\n各个属性空格分割"
-            "\n详细：http://oy.mk/cUm"
-        )
 
 
 # 处理带多个值的订阅参数
@@ -136,34 +108,67 @@ async def handle_change_list(
     setattr(rss, attribute_dict.get(key_to_change), value_to_change)
 
 
-@RSS_CHANGE.got("RSS_CHANGE", prompt="")
+prompt = (
+    "请输入要修改的订阅"
+    "\n订阅名[,订阅名,...] 属性=值[ 属性=值 ...]"
+    "\n如:"
+    "\ntest1[,test2,...] qq=,123,234 qun=-1"
+    "\n对应参数:"
+    "\n订阅名-name 禁止将多个订阅批量改名，会因为名称相同起冲突"
+    "\n订阅链接-url QQ-qq 群-qun 更新频率-time"
+    "\n代理-proxy 翻译-tl 仅title-ot，仅图片-op，仅含有图片-ohp"
+    "\n下载种子-downopen 白名单关键词-wkey 黑名单关键词-bkey 种子上传到群-upgroup"
+    "\n去重模式-mode"
+    "\n图片数量限制-img_num 只发送限定数量的图片，防止刷屏"
+    "\n正文待移除内容-rm_list 从正文中要移除的指定内容，支持正则"
+    "\n停止更新-stop"
+    "\n注："
+    "\n仅含有图片不同于仅图片，除了图片还会发送正文中的其他文本信息"
+    "\nproxy、tl、ot、op、ohp、downopen、upgroup、stop 值为 1/0"
+    "\n去重模式分为按链接(link)、标题(title)、图片(image)判断"
+    "\n其中 image 模式,出于性能考虑以及避免误伤情况发生,生效对象限定为只带 1 张图片的消息,"
+    "\n此外,如果属性中带有 or 说明判断逻辑是任一匹配即去重,默认为全匹配"
+    "\n白名单关键词支持正则表达式，匹配时推送消息及下载，设为空(wkey=)时不生效"
+    "\n黑名单关键词同白名单一样，只是匹配时不推送，两者可以一起用"
+    "\n正文待移除内容因为参数解析的缘故，格式必须如：rm_list='a' 或 rm_list='a','b'"
+    "\n该处理过程是在解析 html 标签后进行的"
+    "\n要将该参数设为空使用 rm_list='-1'"
+    "\nQQ、群号、去重模式前加英文逗号表示追加,-1设为空"
+    "\n各个属性空格分割"
+    "\n详细：https://oy.mk/cUm"
+)
+
+
+@RSS_CHANGE.got("RSS_CHANGE", prompt=prompt)
 async def handle_rss_change(bot: Bot, event: Event, state: dict):
     change_info = unescape(state["RSS_CHANGE"])
     group_id = None
     if isinstance(event, GroupMessageEvent):
         group_id = event.group_id
-    # 参数特殊处理：正文待移除内容
-    rm_list_exist = re.search(" rm_list='.+'", change_info)
-    rm_list = None
-    if rm_list_exist:
-        rm_list_str = rm_list_exist[0].lstrip().replace("rm_list=", "")
-        rm_list = [i.strip("'") for i in rm_list_str.split("','")]
-        change_info = change_info.replace(rm_list_exist[0], "")
-    change_list = change_info.split(" ")
 
-    name = change_list[0]
-    change_list.pop(0)
+    name_list = change_info.split(" ")[0].split(",")
     rss = rss_class.Rss()
-    if not rss.find_name(name=name):
-        await RSS_CHANGE.send(f"❌ 订阅 {name} 不存在！")
-        return
+    rss_list = [rss.find_name(name=name) for name in name_list]
+    rss_list = list(filter(lambda x: x is not None, rss_list))
 
-    rss = rss.find_name(name=name)
-    if group_id and str(group_id) not in rss.group_id:
-        await RSS_CHANGE.send(f"❌ 修改失败，当前群组无权操作订阅：{rss.name}")
-        return
+    if group_id:
+        rss_list = list(filter(lambda x: str(group_id) in x.group_id, rss_list))
 
-    try:
+    if not rss_list:
+        await RSS_CHANGE.send("❌ 请检查是否存在以下问题：\n1.要修改的订阅名不存在对应的记录\n2.当前群组无权操作")
+    else:
+        if len(rss_list) > 1 and " name=" in change_info:
+            await RSS_CHANGE.send("❌ 禁止将多个订阅批量改名！会因为名称相同起冲突！")
+            return
+
+    # 参数特殊处理：正文待移除内容
+    change_list = await handle_rm_list(rss_list, change_info)
+
+    rss_msg_list = []
+    result_msg = "----------------------\n"
+
+    for rss in rss_list:
+        rss_name = rss.name
         for change_dict in change_list:
             key_to_change, value_to_change = change_dict.split("=", 1)
             if key_to_change in attribute_dict.keys():
@@ -177,13 +182,9 @@ async def handle_rss_change(bot: Bot, event: Event, state: dict):
                     return
                 await handle_change_list(rss, key_to_change, value_to_change, group_id)
             else:
-                await RSS_CHANGE.send(f"❌ 参数错误或无权修改！\n{change_dict}")
+                await RSS_CHANGE.send(f"❌ 参数错误！\n{change_dict}")
                 return
-        if rm_list:
-            if len(rm_list) == 1 and rm_list[0] == "-1":
-                setattr(rss, "content_to_remove", None)
-            else:
-                setattr(rss, "content_to_remove", rm_list)
+
         # 参数解析完毕，写入
         db = TinyDB(
             JSON_PATH,
@@ -192,7 +193,8 @@ async def handle_rss_change(bot: Bot, event: Event, state: dict):
             indent=4,
             ensure_ascii=False,
         )
-        db.update(rss.__dict__, Query().name == name)
+        db.update(rss.__dict__, Query().name == str(rss_name))
+
         # 加入定时任务
         if not rss.stop:
             await tr.add_job(rss)
@@ -200,6 +202,7 @@ async def handle_rss_change(bot: Bot, event: Event, state: dict):
             await tr.delete_job(rss)
             logger.info(f"{rss.name} 已停止更新")
         rss_msg = str(rss)
+
         if group_id:
             # 隐私考虑，群组下不展示除当前群组外的群号和QQ
             # 奇怪的逻辑，群管理能修改订阅消息，这对其他订阅者不公平。
@@ -207,10 +210,34 @@ async def handle_rss_change(bot: Bot, event: Event, state: dict):
             rss_tmp.group_id = [str(group_id), "*"]
             rss_tmp.user_id = ["*"]
             rss_msg = str(rss_tmp)
-        await RSS_CHANGE.send(f"👏 修改成功\n{rss_msg}")
-        logger.info(f"👏 修改成功\n{rss_msg}")
 
-    except Exception as e:
-        await RSS_CHANGE.send(f"❌ 参数解析出现错误！\nE: {e}")
-        logger.error(f"❌ 参数解析出现错误！\nE: {e}")
-        raise
+        rss_msg_list.append(rss_msg)
+
+    result_msg += result_msg.join(rss_msg_list)
+    await RSS_CHANGE.send(f"👏 修改成功\n{result_msg}")
+    logger.info(f"👏 修改成功\n{result_msg}")
+
+
+# 参数特殊处理：正文待移除内容
+async def handle_rm_list(rss_list: List[rss_class.Rss], change_info: str) -> list:
+    rm_list_exist = re.search(" rm_list='.+'", change_info)
+    rm_list = None
+
+    if rm_list_exist:
+        rm_list_str = rm_list_exist[0].lstrip().replace("rm_list=", "")
+        rm_list = [i.strip("'") for i in rm_list_str.split("','")]
+        change_info = change_info.replace(rm_list_exist[0], "")
+
+    if rm_list:
+        if len(rm_list) == 1 and rm_list[0] == "-1":
+            for rss in rss_list:
+                setattr(rss, "content_to_remove", None)
+        else:
+            for rss in rss_list:
+                setattr(rss, "content_to_remove", rm_list)
+
+    change_list = change_info.split(" ")
+    # 去掉订阅名
+    change_list.pop(0)
+
+    return change_list

--- a/src/plugins/ELF_RSS2/show_all.py
+++ b/src/plugins/ELF_RSS2/show_all.py
@@ -9,8 +9,8 @@ from .RSS import rss_class
 from .show_dy import handle_rss_list
 
 RSS_SHOW_ALL = on_command(
-    "showall",
-    aliases={"selectall", "所有订阅"},
+    "show_all",
+    aliases={"showall", "select_all", "selectall", "所有订阅"},
     rule=to_me(),
     priority=5,
     permission=su.SUPERUSER | permission.GROUP_ADMIN | permission.GROUP_OWNER,

--- a/src/plugins/ELF_RSS2/show_dy.py
+++ b/src/plugins/ELF_RSS2/show_dy.py
@@ -23,8 +23,10 @@ async def handle_rss_list(rss_list: list) -> str:
     rss_stopped_info_list = [f"{i.name}：{i.url}" for i in rss_list if i.stop]
     if rss_stopped_info_list:
         rss_stopped_info_list.sort()
-        msg_str += f"\n\n其中共有 {len(rss_stopped_info_list)} 条订阅已停止更新：\n\n" + "\n\n".join(
-            rss_stopped_info_list
+        msg_str += (
+            f"\n----------------------\n"
+            f"其中共有 {len(rss_stopped_info_list)} 条订阅已停止更新：\n\n"
+            + "\n\n".join(rss_stopped_info_list)
         )
     return msg_str
 

--- a/src/plugins/ELF_RSS2/start.py
+++ b/src/plugins/ELF_RSS2/start.py
@@ -94,7 +94,7 @@ def change_rss_json():
 async def start():
     (bot,) = nonebot.get_bots().values()
 
-    if config.version == "v2.4.0":
+    if config.version <= "v2.4.1":
         change_rss_json()
         change_cache_json()
 


### PR DESCRIPTION
:sparkles: 添加新特性

- 增加对订阅属性 `name` 的修改
- 为 `show_all` 增加针对QQ和群组的关键词过滤功能，仅对超级管理员用户生效
- 为 `change` 增加批量修改功能,即支持同时对多个订阅进行修改

:bug: 修复 BUG

- 给 `change_rss_json()` 加个判断逻辑，跳过无 `rss.json` 的情况
- 修正 `change_cache_json()` 的逻辑
- 修正 `handle_check_update` 的逻辑
- 修正 `start()` 的逻辑
- 一些情况下响应头里没有 `Content-Type` 字段
- 修正 `判断文件是否存在` 的逻辑

:recycle: 重构代码

- 重构 `rss_class` 初始化相关逻辑
- 重构 `缓存 json 的读写` 相关逻辑
- 精简 `缓存 json` 中的字段
- 重构 `cache_filter()` 的逻辑
- 重构 `cache_json_manage()` 的逻辑
- 把 `data 目录路径` 改为共享变量
- 充分利用 `pathlib` 带来的便利性
- 重构 `handle_date` 相关逻辑
- 重构 `对结果按照发布时间排序` 的逻辑

:art: 改进结构和代码格式

:fire: 移除代码或文件
