### PR TITLE
V2.4.3

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,2 @@
 ENVIRONMENT=prod
-VERSION='v2.4.2'
+VERSION='v2.4.3'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ELF_RSS"
-version = "2.4.2"
+version = "2.4.3"
 description = "ELF_RSS"
 authors = ["Quan666"]
 license = "GPL v3"

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r", encoding="UTF-8") as fh:
 
 setuptools.setup(
     name="ELF_RSS",
-    version="2.4.2",
+    version="2.4.3",
     author="Quan666",
     author_email="i@oy.mk",
     description="QQ机器人 RSS订阅 插件，订阅源建议选择 RSSHub",

--- a/src/plugins/ELF_RSS2/RSS/routes/Parsing/cache_manage.py
+++ b/src/plugins/ELF_RSS2/RSS/routes/Parsing/cache_manage.py
@@ -7,6 +7,7 @@ from nonebot.log import logger
 from pyquery import PyQuery as Pq
 from tinydb import TinyDB
 
+from .check_update import get_item_date
 from .handle_images import download_image
 from ... import rss_class
 from ....config import config
@@ -63,7 +64,9 @@ async def cache_db_manage(conn: sqlite3.connect) -> None:
 async def cache_json_manage(db: TinyDB, new_data_length: int) -> None:
     # 只保留最多 config.limit + new_data_length 条的记录
     limit = config.limit + new_data_length
-    retains = db.all()[-limit:]
+    retains = db.all()
+    retains.sort(key=get_item_date)
+    retains = retains[-limit:]
     db.truncate()
     db.insert_multiple(retains)
 

--- a/src/plugins/ELF_RSS2/RSS/routes/__init__.py
+++ b/src/plugins/ELF_RSS2/RSS/routes/__init__.py
@@ -1,1 +1,1 @@
-from . import nga, pixiv, south_plus, weibo  # noqa
+from . import nga, pixiv, south_plus, weibo, danbooru  # noqa

--- a/src/plugins/ELF_RSS2/RSS/routes/danbooru.py
+++ b/src/plugins/ELF_RSS2/RSS/routes/danbooru.py
@@ -1,0 +1,48 @@
+import httpx
+
+from pyquery import PyQuery as Pq
+
+from .Parsing import ParsingBase, get_proxy
+from .Parsing.handle_images import handle_img_combo
+from ..rss_class import Rss
+
+
+# 处理图片
+@ParsingBase.append_handler(parsing_type="picture", rex="danbooru")
+async def handle_picture(
+    rss: Rss, state: dict, item: dict, item_msg: str, tmp: str, tmp_state: dict
+) -> str:
+
+    # 判断是否开启了只推送标题
+    if rss.only_title:
+        return ""
+
+    res = await handle_img(
+        url=item["link"],
+        img_proxy=rss.img_proxy,
+    )
+
+    # 判断是否开启了只推送图片
+    if rss.only_pic:
+        return f"{res}\n"
+
+    return f"{tmp + res}\n"
+
+
+# 处理图片、视频
+async def handle_img(url: str, img_proxy: bool) -> str:
+    img_str = ""
+
+    # 处理图片
+    async with httpx.AsyncClient(proxies=get_proxy(img_proxy)) as client:
+        response = await client.get(url)
+        d = Pq(response.text)
+        img = d("img#image")
+        if img:
+            url = img.attr("src")
+        else:
+            img_str += "视频封面："
+            url = d("meta[property='og:image']").attr("content")
+        img_str += await handle_img_combo(url, img_proxy)
+
+    return img_str

--- a/src/plugins/ELF_RSS2/RSS/routes/danbooru.py
+++ b/src/plugins/ELF_RSS2/RSS/routes/danbooru.py
@@ -76,7 +76,7 @@ async def handle_check_update(rss: Rss, state: dict):
 
     delete = []
     for index, item in enumerate(change_data):
-        summary = get_summary(item, rss.img_proxy)
+        summary = await get_summary(item, rss.img_proxy)
         is_duplicate, image_hash = await duplicate_exists(
             rss=rss,
             conn=conn,
@@ -101,7 +101,7 @@ async def handle_check_update(rss: Rss, state: dict):
 
 
 # 获取正文
-def get_summary(item: dict, img_proxy: bool) -> str:
+async def get_summary(item: dict, img_proxy: bool) -> str:
     summary = (
         item["content"][0].get("value") if item.get("content") else item["summary"]
     )

--- a/src/plugins/ELF_RSS2/RSS/routes/danbooru.py
+++ b/src/plugins/ELF_RSS2/RSS/routes/danbooru.py
@@ -1,10 +1,19 @@
 import httpx
+import sqlite3
 
+from nonebot import logger
 from pyquery import PyQuery as Pq
 
-from .Parsing import ParsingBase, get_proxy
+from .Parsing import (
+    ParsingBase,
+    get_proxy,
+    write_item,
+    cache_db_manage,
+    duplicate_exists,
+)
 from .Parsing.handle_images import handle_img_combo
 from ..rss_class import Rss
+from ...config import DATA_PATH
 
 
 # 处理图片
@@ -46,3 +55,62 @@ async def handle_img(url: str, img_proxy: bool) -> str:
         img_str += await handle_img_combo(url, img_proxy)
 
     return img_str
+
+
+# 如果启用了去重模式，对推送列表进行过滤
+@ParsingBase.append_before_handler(priority=12, rex="danbooru")
+async def handle_check_update(rss: Rss, state: dict):
+    change_data = state.get("change_data")
+    conn = state.get("conn")
+    db = state.get("tinydb")
+
+    # 检查是否启用去重 使用 duplicate_filter_mode 字段
+    if not rss.duplicate_filter_mode:
+        return {"change_data": change_data}
+
+    if not conn:
+        conn = sqlite3.connect(DATA_PATH / "cache.db")
+        conn.set_trace_callback(logger.debug)
+
+    await cache_db_manage(conn)
+
+    delete = []
+    for index, item in enumerate(change_data):
+        summary = get_summary(item, rss.img_proxy)
+        is_duplicate, image_hash = await duplicate_exists(
+            rss=rss,
+            conn=conn,
+            link=item["link"],
+            title=item["title"],
+            summary=summary,
+        )
+        if is_duplicate:
+            write_item(db, item)
+            delete.append(index)
+        else:
+            change_data[index]["image_hash"] = str(image_hash)
+
+    change_data = [
+        item for index, item in enumerate(change_data) if index not in delete
+    ]
+
+    return {
+        "change_data": change_data,
+        "conn": conn,
+    }
+
+
+# 获取正文
+def get_summary(item: dict, img_proxy: bool) -> str:
+    summary = (
+        item["content"][0].get("value") if item.get("content") else item["summary"]
+    )
+    # 如果图片非视频封面，替换为更清晰的预览图
+    summary_doc = Pq(summary)
+    async with httpx.AsyncClient(proxies=get_proxy(img_proxy)) as client:
+        response = await client.get(item["link"])
+        d = Pq(response.text)
+        img = d("img#image")
+        if img:
+            summary_doc("img").attr("src", img.attr("src"))
+    return str(summary_doc)


### PR DESCRIPTION
:sparkles: 添加新特性

- 增加对 `danbooru` 订阅源的处理

:bug: 修复 BUG

- 处理日期的时候，没考虑到极个别订阅没有 `发布日期` 字段的情况
- 第一次启动时没有 data 目录
- 修正 `日期处理` 的逻辑
- 修正 `写入缓存 json` 的逻辑

:recycle: 重构代码

- 重构 `cache_json_manage()` 的逻辑，针对抓取到的记录数可能多于缓存设置上限的极端情况
- 补上对 `u` 标签的处理
- 修改订阅成功后，返回信息中增加 `修改生效订阅数`
- 修正 `cache_json_manage()` 的逻辑，确保留存的记录为最新的
- 处理 `danbooru` 订阅源时，获取正文后如果图片非视频封面，替换为更清晰的预览图

:art: 改进结构和代码格式
