### PR TITLE
修正图片下载重试的逻辑，去掉多余的内嵌 `AsyncClient`

### DIFF
--- a/src/plugins/ELF_RSS2/RSS/routes/Parsing/handle_images.py
+++ b/src/plugins/ELF_RSS2/RSS/routes/Parsing/handle_images.py
@@ -131,16 +131,16 @@ async def download_image_detail(url: str, proxy: bool):
         headers = {"referer": referer}
         try:
             pic = await client.get(url, headers=headers)
-        except httpx.ConnectError as e:
-            logger.error(f"图片[{url}]下载失败，有可能需要开启代理！\n{e}")
-            return None
+        except Exception as e:
+            logger.warning(f"图片[{url}]下载失败！将重试最多 5 次！\n{e}")
+            raise
         # 如果图片无法获取到，直接返回
         if (len(pic.content) == 0) or (pic.status_code not in STATUS_CODE):
             if "pixiv.cat" in url:
                 url = await fuck_pixiv_cat(url=url)
                 return await download_image(url, proxy)
             logger.error(
-                f"[{url}] Content-Type: {pic.headers.get('Content-Type')} status_code: {pic.status_code}"
+                f"图片[{url}]下载失败！ Content-Type: {pic.headers.get('Content-Type')} status_code: {pic.status_code}"
             )
             return None
         return pic.content
@@ -150,7 +150,7 @@ async def download_image(url: str, proxy: bool = False):
     try:
         return await download_image_detail(url=url, proxy=proxy)
     except RetryError:
-        logger.error(f"图片[{url}]下载失败！已达最大重试次数！")
+        logger.error(f"图片[{url}]下载失败！已达最大重试次数！有可能需要开启代理！")
         return None
 
 

--- a/src/plugins/ELF_RSS2/RSS/routes/Parsing/handle_images.py
+++ b/src/plugins/ELF_RSS2/RSS/routes/Parsing/handle_images.py
@@ -38,11 +38,10 @@ async def resize_gif(url: str, resize_ratio: int = 2) -> BytesIO:
             "method": "gifsicle",
             "ar": "force",
         }
-        async with httpx.AsyncClient() as fork_client:
-            response = await fork_client.post(url=next_url + "?ajax=true", data=data)
-            d = Pq(response.text)
-            output_img_url = "https:" + d("img:nth-child(1)").attr("src")
-            return await download_image(output_img_url)
+        response = await client.post(url=next_url + "?ajax=true", data=data)
+        d = Pq(response.text)
+        output_img_url = "https:" + d("img:nth-child(1)").attr("src")
+        return await download_image(output_img_url)
 
 
 # 图片压缩

--- a/src/plugins/ELF_RSS2/RSS/rss_parsing.py
+++ b/src/plugins/ELF_RSS2/RSS/rss_parsing.py
@@ -106,21 +106,20 @@ async def get_rss(rss: rss_class.Rss) -> dict:
             ):
                 logger.warning(f"[{rss.get_url()}]访问失败！将使用备用 RSSHub 地址！")
                 for rsshub_url in list(config.rsshub_backup):
-                    async with httpx.AsyncClient(proxies=proxies) as fork_client:
-                        try:
-                            r = await fork_client.get(rss.get_url(rsshub=rsshub_url))
-                            if r.status_code in STATUS_CODE:
-                                d = feedparser.parse(r.content)
-                            else:
-                                raise httpx.HTTPStatusError
-                        except Exception:
-                            logger.warning(
-                                f"[{rss.get_url(rsshub=rsshub_url)}]访问失败！将使用备用 RSSHub 地址！"
-                            )
-                            continue
-                        if d.get("feed"):
-                            logger.info(f"[{rss.get_url(rsshub=rsshub_url)}]抓取成功！")
-                            break
+                    try:
+                        r = await client.get(rss.get_url(rsshub=rsshub_url))
+                        if r.status_code in STATUS_CODE:
+                            d = feedparser.parse(r.content)
+                        else:
+                            raise httpx.HTTPStatusError
+                    except Exception:
+                        logger.warning(
+                            f"[{rss.get_url(rsshub=rsshub_url)}]访问失败！将使用备用 RSSHub 地址！"
+                        )
+                        continue
+                    if d.get("feed"):
+                        logger.info(f"[{rss.get_url(rsshub=rsshub_url)}]抓取成功！")
+                        break
         finally:
             if not d or not d.get("feed"):
                 logger.warning(f"{rss.name} 抓取失败！将重试最多 5 次！")


### PR DESCRIPTION
- `download_image_detail()` 中的异常捕获后没有往上抛出，导致没触发重试机制。
- 内嵌 `AsyncClient` 没意义。