### PR TITLE
为订阅源 `danbooru` `twitter` 添加从视频获取预览 GIF 的逻辑

### DIFF
--- a/src/plugins/ELF_RSS2/RSS/routes/__init__.py
+++ b/src/plugins/ELF_RSS2/RSS/routes/__init__.py
@@ -1,1 +1,1 @@
-from . import nga, pixiv, south_plus, weibo, danbooru  # noqa
+from . import danbooru, nga, pixiv, south_plus, twitter, weibo  # noqa

--- a/src/plugins/ELF_RSS2/RSS/routes/danbooru.py
+++ b/src/plugins/ELF_RSS2/RSS/routes/danbooru.py
@@ -12,7 +12,7 @@ from .Parsing import (
     cache_db_manage,
     duplicate_exists,
 )
-from .Parsing.handle_images import handle_img_combo
+from .Parsing.handle_images import handle_img_combo, get_preview_gif_from_video
 from ..rss_class import Rss
 from ...config import DATA_PATH
 
@@ -56,8 +56,13 @@ async def handle_img(url: str, img_proxy: bool) -> str:
         if img:
             url = img.attr("src")
         else:
-            img_str += "视频封面："
-            url = d("meta[property='og:image']").attr("content")
+            img_str += "视频预览："
+            url = d("video#image").attr("src")
+            try:
+                url = await get_preview_gif_from_video(url)
+            except RetryError:
+                logger.error(f"视频预览获取失败，将发送原视频封面")
+                url = d("meta[property='og:image']").attr("content")
         img_str += await handle_img_combo(url, img_proxy)
 
     return img_str
@@ -116,7 +121,7 @@ async def get_summary(item: dict, img_proxy: bool) -> str:
     summary = (
         item["content"][0].get("value") if item.get("content") else item["summary"]
     )
-    # 如果图片非视频封面，替换为更清晰的预览图
+    # 如果图片非视频封面，替换为更清晰的预览图；否则移除，以此跳过图片去重检查
     summary_doc = Pq(summary)
     async with httpx.AsyncClient(proxies=get_proxy(img_proxy)) as client:
         response = await client.get(item["link"])
@@ -124,4 +129,6 @@ async def get_summary(item: dict, img_proxy: bool) -> str:
         img = d("img#image")
         if img:
             summary_doc("img").attr("src", img.attr("src"))
+        else:
+            summary_doc.remove("img")
     return str(summary_doc)

--- a/src/plugins/ELF_RSS2/RSS/routes/twitter.py
+++ b/src/plugins/ELF_RSS2/RSS/routes/twitter.py
@@ -1,0 +1,59 @@
+from nonebot import logger
+from pyquery import PyQuery as Pq
+from tenacity import RetryError
+
+from .Parsing import ParsingBase, get_summary
+from .Parsing.handle_images import handle_img_combo, get_preview_gif_from_video
+from ..rss_class import Rss
+
+
+# 处理图片
+@ParsingBase.append_handler(parsing_type="picture", rex="twitter")
+async def handle_picture(
+    rss: Rss, state: dict, item: dict, item_msg: str, tmp: str, tmp_state: dict
+) -> str:
+
+    # 判断是否开启了只推送标题
+    if rss.only_title:
+        return ""
+
+    res = await handle_img(
+        html=Pq(get_summary(item)),
+        img_proxy=rss.img_proxy,
+        img_num=rss.max_image_number,
+    )
+
+    # 判断是否开启了只推送图片
+    if rss.only_pic:
+        return f"{res}\n"
+
+    return f"{tmp + res}\n"
+
+
+# 处理图片、视频
+async def handle_img(html, img_proxy: bool, img_num: int) -> str:
+    img_str = ""
+    # 处理图片
+    doc_img = list(html("img").items())
+    # 只发送限定数量的图片，防止刷屏
+    if 0 < img_num < len(doc_img):
+        img_str += f"\n因启用图片数量限制，目前只有 {img_num} 张图片："
+        doc_img = doc_img[:img_num]
+    for img in doc_img:
+        url = img.attr("src")
+        img_str += await handle_img_combo(url, img_proxy)
+
+    # 处理视频
+    doc_video = html("video")
+    if doc_video:
+        img_str += "\n视频预览："
+        for video in doc_video.items():
+            url = video.attr("src")
+            try:
+                url = await get_preview_gif_from_video(url)
+            except RetryError:
+                logger.error(f"视频预览获取失败，将发送原视频封面")
+                url = video.attr("poster")
+            img_str += await handle_img_combo(url, img_proxy)
+
+    return img_str


### PR DESCRIPTION
暂时只是特定订阅源逻辑，不加入可选订阅源参数。