### PR TITLE
一些重构和新特性

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,4 +138,6 @@ dmypy.json
 # pytype static type analyzer
 .pytype/
 .idea/
+.env.prod
+data/
 # End of https://www.toptal.com/developers/gitignore/api/python

--- a/src/plugins/ELF_RSS2/RSS/routes/Parsing/handle_images.py
+++ b/src/plugins/ELF_RSS2/RSS/routes/Parsing/handle_images.py
@@ -224,8 +224,18 @@ async def handle_img(html, img_proxy: bool, img_num: int) -> str:
             url = video.attr("poster")
             img_str += await handle_img_combo(url, img_proxy)
 
-    # 解决 issue 36
+    return img_str
+
+
+# 处理 bbcode 图片
+async def handle_bbcode_img(html, img_proxy: bool, img_num: int) -> str:
+    img_str = ""
+    # 处理图片
     img_list = re.findall(r"\[img](.+?)\[/img]", str(html), flags=re.I)
+    # 只发送限定数量的图片，防止刷屏
+    if 0 < img_num < len(img_list):
+        img_str += f"\n因启用图片数量限制，目前只有 {img_num} 张图片："
+        img_list = img_list[:img_num]
     for img_tmp in img_list:
         img_str += await handle_img_combo(img_tmp, img_proxy)
 

--- a/src/plugins/ELF_RSS2/RSS/routes/Parsing/handle_images.py
+++ b/src/plugins/ELF_RSS2/RSS/routes/Parsing/handle_images.py
@@ -64,7 +64,7 @@ async def get_preview_gif_from_video(url: str) -> str:
         file = d("form > input[type=hidden]:nth-child(1)").attr("value")
         token = d("form > input[type=hidden]:nth-child(2)").attr("value")
         default_end = d("#end").attr("value")
-        if default_end == "5":
+        if float(default_end) >= 4:
             start = video_length_median - 2
             end = video_length_median + 2
         else:

--- a/src/plugins/ELF_RSS2/RSS/routes/danbooru.py
+++ b/src/plugins/ELF_RSS2/RSS/routes/danbooru.py
@@ -32,9 +32,9 @@ async def handle_picture(
             url=item["link"],
             img_proxy=rss.img_proxy,
         )
-    except RetryError:
+    except RetryError as e:
         res = "预览图获取失败"
-        logger.error(f"[{item['link']}]的预览图获取失败")
+        logger.error(f"[{item['link']}]的预览图获取失败 {e}")
 
     # 判断是否开启了只推送图片
     if rss.only_pic:
@@ -61,7 +61,7 @@ async def handle_img(url: str, img_proxy: bool) -> str:
             try:
                 url = await get_preview_gif_from_video(url)
             except RetryError:
-                logger.error(f"视频预览获取失败，将发送原视频封面")
+                logger.warning(f"视频预览获取失败，将发送原视频封面")
                 url = d("meta[property='og:image']").attr("content")
         img_str += await handle_img_combo(url, img_proxy)
 

--- a/src/plugins/ELF_RSS2/RSS/routes/pixiv.py
+++ b/src/plugins/ELF_RSS2/RSS/routes/pixiv.py
@@ -1,10 +1,81 @@
+import httpx
 import re
 
+from nonebot import logger
+from pyquery import PyQuery as Pq
+from tenacity import retry, stop_after_attempt, stop_after_delay, RetryError
 from tinydb import TinyDB, Query
 
-from .Parsing import ParsingBase
+from .Parsing import ParsingBase, get_summary
 from .Parsing.check_update import get_item_date
+from .Parsing.handle_images import handle_img_combo, get_preview_gif_from_video
 from ..rss_class import Rss
+
+
+# 处理图片
+@ParsingBase.append_handler(parsing_type="picture", rex="pixiv")
+async def handle_picture(
+    rss: Rss, state: dict, item: dict, item_msg: str, tmp: str, tmp_state: dict
+) -> str:
+
+    # 判断是否开启了只推送标题
+    if rss.only_title:
+        return ""
+
+    res = ""
+    try:
+        res += await handle_img(
+            html=Pq(get_summary(item)),
+            link=item["link"],
+            img_proxy=rss.img_proxy,
+            img_num=rss.max_image_number,
+        )
+    except Exception as e:
+        logger.warning(f"{rss.name} 没有正文内容！{e}")
+
+    # 判断是否开启了只推送图片
+    if rss.only_pic:
+        return f"{res}\n"
+
+    return f"{tmp + res}\n"
+
+
+# 处理图片、视频
+@retry(stop=(stop_after_attempt(5) | stop_after_delay(30)))
+async def handle_img(html, link: str, img_proxy: bool, img_num: int) -> str:
+    img_str = ""
+    # 处理动图
+    if re.search("类型：ugoira", str(html)):
+        ugoira_id = re.search(r"\d+", link).group()
+        try:
+            url = await get_ugoira_video(ugoira_id)
+            url = await get_preview_gif_from_video(url)
+            img_str += await handle_img_combo(url, img_proxy)
+        except RetryError:
+            logger.warning(f"动图[{link}]的预览图获取失败，将发送原动图封面")
+            url = html("img").attr("src")
+            img_str += await handle_img_combo(url, img_proxy)
+    else:
+        # 处理图片
+        doc_img = list(html("img").items())
+        # 只发送限定数量的图片，防止刷屏
+        if 0 < img_num < len(doc_img):
+            img_str += f"\n因启用图片数量限制，目前只有 {img_num} 张图片："
+            doc_img = doc_img[:img_num]
+        for img in doc_img:
+            url = img.attr("src")
+            img_str += await handle_img_combo(url, img_proxy)
+
+    return img_str
+
+
+# 获取动图为视频
+@retry(stop=(stop_after_attempt(5) | stop_after_delay(30)))
+async def get_ugoira_video(ugoira_id: str) -> str:
+    async with httpx.AsyncClient() as client:
+        data = {"id": ugoira_id, "type": "ugoira"}
+        response = await client.post("https://ugoira.huggy.moe/api/illusts", data=data)
+        return response.json().get("data")[0].get("url")
 
 
 # 处理来源

--- a/src/plugins/ELF_RSS2/RSS/routes/pixiv.py
+++ b/src/plugins/ELF_RSS2/RSS/routes/pixiv.py
@@ -1,15 +1,74 @@
 import httpx
 import re
+import sqlite3
 
 from nonebot import logger
 from pyquery import PyQuery as Pq
-from tenacity import retry, stop_after_attempt, stop_after_delay, RetryError
+from tenacity import retry, stop_after_attempt, stop_after_delay, RetryError, TryAgain
 from tinydb import TinyDB, Query
 
-from .Parsing import ParsingBase, get_summary
+from .Parsing import (
+    ParsingBase,
+    get_summary,
+    cache_db_manage,
+    write_item,
+    duplicate_exists,
+)
 from .Parsing.check_update import get_item_date
 from .Parsing.handle_images import handle_img_combo, get_preview_gif_from_video
 from ..rss_class import Rss
+from ...config import DATA_PATH
+
+
+# 如果启用了去重模式，对推送列表进行过滤
+@ParsingBase.append_before_handler(priority=12, rex="pixiv")
+async def handle_check_update(rss: Rss, state: dict):
+    change_data = state.get("change_data")
+    conn = state.get("conn")
+    db = state.get("tinydb")
+
+    # 检查是否启用去重 使用 duplicate_filter_mode 字段
+    if not rss.duplicate_filter_mode:
+        return {"change_data": change_data}
+
+    if not conn:
+        conn = sqlite3.connect(DATA_PATH / "cache.db")
+        conn.set_trace_callback(logger.debug)
+
+    await cache_db_manage(conn)
+
+    delete = []
+    for index, item in enumerate(change_data):
+        summary = get_summary(item)
+        try:
+            summary_doc = Pq(summary)
+            # 如果图片为动图，通过移除来跳过图片去重检查
+            if re.search("类型：ugoira", str(summary_doc)):
+                summary_doc.remove("img")
+                summary = str(summary_doc)
+        except Exception as e:
+            logger.warning(e)
+        is_duplicate, image_hash = await duplicate_exists(
+            rss=rss,
+            conn=conn,
+            link=item["link"],
+            title=item["title"],
+            summary=summary,
+        )
+        if is_duplicate:
+            write_item(db, item)
+            delete.append(index)
+        else:
+            change_data[index]["image_hash"] = str(image_hash)
+
+    change_data = [
+        item for index, item in enumerate(change_data) if index not in delete
+    ]
+
+    return {
+        "change_data": change_data,
+        "conn": conn,
+    }
 
 
 # 处理图片
@@ -75,7 +134,10 @@ async def get_ugoira_video(ugoira_id: str) -> str:
     async with httpx.AsyncClient() as client:
         data = {"id": ugoira_id, "type": "ugoira"}
         response = await client.post("https://ugoira.huggy.moe/api/illusts", data=data)
-        return response.json().get("data")[0].get("url")
+        url = response.json().get("data")[0].get("url")
+        if not url:
+            raise TryAgain
+        return url
 
 
 # 处理来源

--- a/src/plugins/ELF_RSS2/RSS/routes/south_plus.py
+++ b/src/plugins/ELF_RSS2/RSS/routes/south_plus.py
@@ -21,7 +21,7 @@ async def handle_summary(
 
 
 # 处理图片
-@ParsingBase.append_handler(parsing_type="picture", rex="south|spring)-plus.net")
+@ParsingBase.append_handler(parsing_type="picture", rex="(south|spring)-plus.net")
 async def handle_picture(
     rss: Rss, state: dict, item: dict, item_msg: str, tmp: str, tmp_state: dict
 ) -> str:

--- a/src/plugins/ELF_RSS2/RSS/routes/south_plus.py
+++ b/src/plugins/ELF_RSS2/RSS/routes/south_plus.py
@@ -1,8 +1,10 @@
 import re
 
+from nonebot import logger
 from pyquery import PyQuery as Pq
 
 from .Parsing import ParsingBase, get_summary, handle_bbcode, handle_html_tag
+from .Parsing.handle_images import handle_bbcode_img
 from ..rss_class import Rss
 
 
@@ -16,6 +18,33 @@ async def handle_summary(
     rss_str = await handle_bbcode(html=Pq(get_summary(item)))
     tmp += await handle_html_tag(html=Pq(rss_str))
     return tmp
+
+
+# 处理图片
+@ParsingBase.append_handler(parsing_type="picture", rex="south|spring)-plus.net")
+async def handle_picture(
+    rss: Rss, state: dict, item: dict, item_msg: str, tmp: str, tmp_state: dict
+) -> str:
+
+    # 判断是否开启了只推送标题
+    if rss.only_title:
+        return ""
+
+    res = ""
+    try:
+        res += await handle_bbcode_img(
+            html=Pq(get_summary(item)),
+            img_proxy=rss.img_proxy,
+            img_num=rss.max_image_number,
+        )
+    except Exception as e:
+        logger.warning(f"{rss.name} 没有正文内容！{e}")
+
+    # 判断是否开启了只推送图片
+    if rss.only_pic:
+        return f"{res}\n"
+
+    return f"{tmp + res}\n"
 
 
 # 处理来源

--- a/src/plugins/ELF_RSS2/RSS/routes/twitter.py
+++ b/src/plugins/ELF_RSS2/RSS/routes/twitter.py
@@ -52,7 +52,7 @@ async def handle_img(html, img_proxy: bool, img_num: int) -> str:
             try:
                 url = await get_preview_gif_from_video(url)
             except RetryError:
-                logger.error(f"视频预览获取失败，将发送原视频封面")
+                logger.warning(f"视频预览获取失败，将发送原视频封面")
                 url = video.attr("poster")
             img_str += await handle_img_combo(url, img_proxy)
 


### PR DESCRIPTION
:recycle: 重构代码

- 将原来针对 bbcode 图片的处理逻辑独立出来
- 修正 `get_preview_gif_from_video` 的逻辑
- 修正 `get_ugoira_video` 的逻辑 - 为订阅源 `pixiv` 增加当图片为动图时跳过图片去重判断的逻辑

:sparkles: 添加新特性

- 为订阅源 `pixiv` 添加为动图获取预览 GIF 的逻辑