### PR TITLE
关于 yande.re 预览图及图片 hash 算法的改动

### DIFF
--- a/src/plugins/ELF_RSS2/RSS/routes/Parsing/cache_manage.py
+++ b/src/plugins/ELF_RSS2/RSS/routes/Parsing/cache_manage.py
@@ -108,7 +108,7 @@ async def duplicate_exists(
             if im.format == "GIF":
                 item["gif_url"] = url
                 continue
-            image_hash = str(imagehash.average_hash(im))
+            image_hash = str(imagehash.dhash(im))
             logger.debug(f"image_hash: {image_hash}")
             sql += " AND image_hash=?"
             args.append(image_hash)

--- a/src/plugins/ELF_RSS2/RSS/routes/__init__.py
+++ b/src/plugins/ELF_RSS2/RSS/routes/__init__.py
@@ -5,5 +5,6 @@ from . import (
     south_plus,
     twitter,
     weibo,
+    yande_re,
     youtube,
 )  # noqa

--- a/src/plugins/ELF_RSS2/RSS/routes/yande_re.py
+++ b/src/plugins/ELF_RSS2/RSS/routes/yande_re.py
@@ -1,0 +1,18 @@
+import re
+
+from .Parsing import ParsingBase, check_update
+from ..rss_class import Rss
+
+
+# 检查更新
+@ParsingBase.append_before_handler(
+    priority=10, rex=r"https\:\/\/yande\.re\/post\/piclens\?tags\="
+)
+async def handle_check_update(rss: Rss, state: dict):
+    db = state.get("tinydb")
+    change_data = await check_update(db, state.get("new_data"))
+    for i in change_data:
+        i["summary"] = re.sub(
+            r'https://[^"]+', i["media_content"][0]["url"], i["summary"]
+        )
+    return {"change_data": change_data}


### PR DESCRIPTION
针对 `yande.re` 官方的订阅源，添加处理预览图的逻辑
更换图片 hash 算法为 dhash ，提高准确率和效率