### PR TITLE
一点重构

### DIFF
--- a/src/plugins/ELF_RSS2/RSS/routes/Parsing/handle_html_tag.py
+++ b/src/plugins/ELF_RSS2/RSS/routes/Parsing/handle_html_tag.py
@@ -132,7 +132,7 @@ async def handle_html_tag(html) -> str:
         rss_str = re.sub(f"<{i} [^>]+>", "", rss_str)
         rss_str = re.sub(f"</?{i}>", "", rss_str)
 
-    rss_str = re.sub(r"<br\s?/?>|<br [^>]+>|<hr>", "\n", rss_str)
+    rss_str = re.sub(r"<(br|hr)\s?/?>|<(br|hr) [^>]+>", "\n", rss_str)
     rss_str = re.sub(r"<h\d [^>]+>", "\n", rss_str)
     rss_str = re.sub(r"</?h\d>", "\n", rss_str)
 

--- a/src/plugins/ELF_RSS2/RSS/routes/Parsing/handle_translation.py
+++ b/src/plugins/ELF_RSS2/RSS/routes/Parsing/handle_translation.py
@@ -2,7 +2,6 @@ import re
 import unicodedata
 
 import emoji
-
 from translate import Translator
 
 from ....config import config


### PR DESCRIPTION
- 补上对不标准的 `hr` 标签的处理
- 处理图像的时候先把 WEBP 图像转为 PNG
- 优化 `get_pic_base64` 的逻辑