### PR TITLE
:bookmark: 发布 `v2.5.2`

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,2 @@
 ENVIRONMENT=prod
-VERSION='v2.5.1'
+VERSION='v2.5.2'

--- a/docs/部署教程.md
+++ b/docs/部署教程.md
@@ -88,12 +88,7 @@ Windows版安装包下载地址：[https://www.python.org/ftp/python/3.8.3/pytho
 
 5. 复制本仓库中 `.env.dev` 文件内容到工程目录下的 `.env.prod` 文件，并根据注释修改
 
-6. 将以下内容覆盖至工程目录下的 `.env` 文件
-
-    ```
-    ENVIRONMENT=prod
-    VERSION='v2.5.1'
-    ```
+6. 复制本仓库中 `.env` 文件内容到工程目录下的 `.env` 文件
 
 #### 已经部署过其它 Nonebot2 机器人
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ELF_RSS"
-version = "2.5.1"
+version = "2.5.2"
 description = "ELF_RSS"
 authors = ["Quan666"]
 license = "GPL v3"

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r", encoding="UTF-8") as fh:
 
 setuptools.setup(
     name="ELF_RSS",
-    version="2.5.1",
+    version="2.5.2",
     author="Quan666",
     author_email="i@oy.mk",
     description="QQ机器人 RSS订阅 插件，订阅源建议选择 RSSHub",

--- a/src/plugins/ELF_RSS2/RSS/routes/Parsing/handle_html_tag.py
+++ b/src/plugins/ELF_RSS2/RSS/routes/Parsing/handle_html_tag.py
@@ -116,8 +116,10 @@ async def handle_html_tag(html) -> str:
         "strong",
         "sub",
         "table",
+        "tbody",
         "td",
         "th",
+        "thead",
         "tr",
         "u",
         "ul",
@@ -137,7 +139,9 @@ async def handle_html_tag(html) -> str:
     rss_str = re.sub(r"</?h\d>", "\n", rss_str)
 
     # 删除图片、视频标签
-    rss_str = re.sub(r"<video[^>]*>(.*?</video>)?|<img[^>]+>", "", rss_str)
+    rss_str = re.sub(
+        r"<video[^>]*>(.*?</video>)?|<img[^>]+>", "", rss_str, flags=re.DOTALL
+    )
 
     # 去掉多余换行
     while "\n\n\n" in rss_str:

--- a/src/plugins/ELF_RSS2/RSS/rss_parsing.py
+++ b/src/plugins/ELF_RSS2/RSS/rss_parsing.py
@@ -7,7 +7,14 @@ from pathlib import Path
 import feedparser
 import httpx
 from nonebot.log import logger
-from tenacity import RetryError, TryAgain, retry, stop_after_attempt, stop_after_delay
+from tenacity import (
+    RetryError,
+    TryAgain,
+    retry,
+    stop_after_attempt,
+    stop_after_delay,
+    wait_fixed,
+)
 from tinydb import TinyDB
 from tinydb.middlewares import CachingMiddleware
 from tinydb.storages import JSONStorage
@@ -70,7 +77,7 @@ async def start(rss: rss_class.Rss) -> None:
 
 
 # 获取 RSS 并解析为 json ，失败重试
-@retry(stop=(stop_after_attempt(5) | stop_after_delay(30)))
+@retry(wait=wait_fixed(1), stop=(stop_after_attempt(5) | stop_after_delay(30)))
 async def get_rss(rss: rss_class.Rss) -> dict:
     proxies = get_proxy(rss.img_proxy)
     # 对本机部署的 RSSHub 不使用代理

--- a/src/plugins/ELF_RSS2/show_dy.py
+++ b/src/plugins/ELF_RSS2/show_dy.py
@@ -28,7 +28,7 @@ async def handle_rss_list(rss_list: list) -> str:
     if rss_stopped_info_list:
         rss_stopped_info_list.sort()
         msg_str += (
-            f"\n----------------------\n"
+            "\n----------------------\n"
             f"其中共有 {len(rss_stopped_info_list)} 条订阅已停止更新：\n\n"
             + "\n\n".join(rss_stopped_info_list)
         )


### PR DESCRIPTION
> 注意：因 Google 翻译库更换，更新到此版本后需要更新项目依赖

:recycle: 重构代码

- 更换使用的 Google 翻译库 （**记得更新依赖**） by @Quan666
- 补上对不标准的 `hr` 标签的处理 by @NekoAria
- 处理图像的时候先把 WEBP 图像转为 PNG by @NekoAria
- 优化 `get_pic_base64` 的逻辑 by @NekoAria
- 补上对 `tbody` `thead` 标签的处理 by @NekoAria
- 修正对 `video` 标签的正则逻辑 by @NekoAria
- 为 `get_rss` 的重试加上 1 秒的间隔，避免在订阅中 rsshub 源占比高的情况下，短时间内过于频繁的访问 by @NekoAria

:bug: 修复 BUG： 发送频道报错消息时 API 名称错误 by @mobyw

:memo: 编写文档 by @mobyw