### PR TITLE
:art: 地址匹配更加严格

### DIFF
--- a/src/plugins/ELF_RSS2/parsing/routes/nga.py
+++ b/src/plugins/ELF_RSS2/parsing/routes/nga.py
@@ -9,7 +9,7 @@ from ..check_update import get_item_date
 
 
 # 检查更新
-@ParsingBase.append_before_handler(rex="nga", priority=10)
+@ParsingBase.append_before_handler(rex="/nga/", priority=10)
 async def handle_check_update(rss: Rss, state: Dict[str, Any]) -> Dict[str, Any]:
     new_data = state["new_data"]
     db = state["tinydb"]

--- a/src/plugins/ELF_RSS2/parsing/routes/pixiv.py
+++ b/src/plugins/ELF_RSS2/parsing/routes/pixiv.py
@@ -21,7 +21,7 @@ from ..utils import get_summary
 
 
 # 如果启用了去重模式，对推送列表进行过滤
-@ParsingBase.append_before_handler(priority=12, rex="pixiv")
+@ParsingBase.append_before_handler(priority=12, rex="/pixiv/")
 async def handle_check_update(rss: Rss, state: Dict[str, Any]) -> Dict[str, Any]:
     change_data = state["change_data"]
     conn = state["conn"]


### PR DESCRIPTION
如果匹配url的话，只有nga3个字母的误伤率太高，比如只要url中包含manga就会误入nga的判断，例子：copymanga路由

https://github.com/mengshouer/HoshinoBot-Plugins/issues/9