### PR TITLE
fix bugs and optimize

### DIFF
--- a/src/plugins/ELF_RSS2/command/add_dy.py
+++ b/src/plugins/ELF_RSS2/command/add_dy.py
@@ -52,21 +52,18 @@ async def handle_rss_add(
         name, url = name_and_url.split(" ")
     except ValueError:
         await RSS_ADD.reject(prompt)
-        return
 
-    if _ := Rss.get_one_by_name(name):
-        await RSS_ADD.finish(f"已存在订阅名为 {name} 的订阅")
+    if rss := Rss.get_one_by_name(name):
+        if rss.url != url:
+            await RSS_ADD.finish(f"已存在订阅名为 {name} 的订阅")
+        else:
+            await add_feed(name, url, event, rss)
         return
 
     await add_feed(name, url, event)
 
 
-async def add_feed(
-    name: str,
-    url: str,
-    event: MessageEvent,
-) -> None:
-    rss = Rss()
+async def add_feed(name: str, url: str, event: MessageEvent, rss: Rss = Rss()) -> None:
     rss.name = name
     rss.url = url
     user = str(event.user_id) if isinstance(event, PrivateMessageEvent) else None

--- a/src/plugins/ELF_RSS2/command/change_dy.py
+++ b/src/plugins/ELF_RSS2/command/change_dy.py
@@ -318,7 +318,7 @@ def handle_rm_list(
             elif valid_rm_list := [i for i in rm_list if regex_validate(i)]:
                 setattr(rss, "content_to_remove", valid_rm_list)
 
-    change_list = [i.strip() for i in change_info.split(" ")]
+    change_list = [i.strip() for i in change_info.split(" ") if i != ""]
     # 去掉订阅名
     change_list.pop(0)
 


### PR DESCRIPTION
reject和finish是raise所以不需要return


rm_list 错误 from https://github.com/mengshouer/HoshinoBot-Plugins/issues/13


add添加订阅时

使用相同订阅名时，直接无法添加给其他群或者好友，需要添加一个全新的订阅
↓↓↓
使用相同订阅名和相同订阅地址时，默认使用同一个订阅配置。