### PR TITLE
v2.6.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ELF_RSS"
-version = "2.6.13"
+version = "2.6.14"
 description = "QQ机器人 RSS订阅 插件，订阅源建议选择 RSSHub"
 authors = ["Quan666 <i@Rori.eMail>"]
 license = "GPL-3.0-only"

--- a/src/plugins/ELF_RSS2/__init__.py
+++ b/src/plugins/ELF_RSS2/__init__.py
@@ -14,7 +14,7 @@ from .utils import send_message_to_admin
 require("nonebot_plugin_apscheduler")
 from nonebot_plugin_apscheduler import scheduler  # noqa
 
-VERSION = "2.6.13"
+VERSION = "2.6.14"
 
 __plugin_meta__ = PluginMetadata(
     name="ELF_RSS",

--- a/src/plugins/ELF_RSS2/__init__.py
+++ b/src/plugins/ELF_RSS2/__init__.py
@@ -34,7 +34,6 @@ start_metaevent = on_metaevent(rule=check_first_connect, temp=True)
 # 启动时发送启动成功信息
 @start_metaevent.handle()
 async def start(bot: Bot) -> None:
-
     # 启动后检查 data 目录，不存在就创建
     if not DATA_PATH.is_dir():
         DATA_PATH.mkdir()

--- a/src/plugins/ELF_RSS2/command/add_dy.py
+++ b/src/plugins/ELF_RSS2/command/add_dy.py
@@ -47,7 +47,6 @@ prompt = """\
 async def handle_rss_add(
     event: MessageEvent, name_and_url: str = ArgPlainText("RSS_ADD")
 ) -> None:
-
     try:
         name, url = name_and_url.split(" ")
     except ValueError:

--- a/src/plugins/ELF_RSS2/parsing/__init__.py
+++ b/src/plugins/ELF_RSS2/parsing/__init__.py
@@ -239,7 +239,6 @@ async def handle_picture(
     tmp: str,
     tmp_state: Dict[str, Any],
 ) -> str:
-
     # 判断是否开启了只推送标题
     if rss.only_title:
         return ""
@@ -342,7 +341,6 @@ async def handle_message(
 
     # 发送消息并写入文件
     if await send_msg(rss=rss, msg=item_msg, item=item):
-
         if rss.duplicate_filter_mode:
             insert_into_cache_db(
                 conn=state["conn"], item=item, image_hash=item["image_hash"]

--- a/src/plugins/ELF_RSS2/parsing/check_update.py
+++ b/src/plugins/ELF_RSS2/parsing/check_update.py
@@ -16,7 +16,6 @@ def dict_hash(dictionary: Dict[str, Any]) -> str:
 
 # 检查更新
 def check_update(db: TinyDB, new: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
-
     # 发送失败 1 次
     to_send_list: List[Dict[str, Any]] = db.search(Query().to_send.exists())
 

--- a/src/plugins/ELF_RSS2/parsing/parsing_rss.py
+++ b/src/plugins/ELF_RSS2/parsing/parsing_rss.py
@@ -134,7 +134,6 @@ def _handler_filter(_handler_list: List[ParsingItem], _url: str) -> List[Parsing
 
 # 解析实例
 class ParsingRss:
-
     # 初始化解析实例
     def __init__(self, rss: Rss):
         self.state: Dict[str, Any] = {}  # 用于存储实例处理中上下文数据

--- a/src/plugins/ELF_RSS2/parsing/routes/__init__.py
+++ b/src/plugins/ELF_RSS2/parsing/routes/__init__.py
@@ -1,1 +1,11 @@
-from . import danbooru, nga, pixiv, south_plus, twitter, weibo, yande_re, youtube
+from . import (
+    bilibili,
+    danbooru,
+    nga,
+    pixiv,
+    south_plus,
+    twitter,
+    weibo,
+    yande_re,
+    youtube,
+)

--- a/src/plugins/ELF_RSS2/parsing/routes/bilibili.py
+++ b/src/plugins/ELF_RSS2/parsing/routes/bilibili.py
@@ -1,0 +1,45 @@
+import re
+
+from typing import Any, Dict
+
+from nonebot.log import logger
+from pyquery import PyQuery as Pq
+
+from ...rss_class import Rss
+from .. import ParsingBase, handle_html_tag
+from ..utils import get_author, get_summary
+
+
+# 处理正文 处理网页 tag
+@ParsingBase.append_handler(parsing_type="summary", rex="/bilibili/", priority=10)
+async def handle_summary(
+    rss: Rss,
+    state: Dict[str, Any],
+    item: Dict[str, Any],
+    item_msg: str,
+    tmp: str,
+    tmp_state: Dict[str, Any],
+) -> str:
+    try:
+        tmp += handle_html_tag(html=Pq(get_summary(item)))
+    except Exception as e:
+        logger.warning(f"{rss.name} 没有正文内容！{e}")
+
+    if author := get_author(item):
+        author = f"UP 主： {author}"
+
+    if "AuthorID:" in tmp:
+        author_id = re.search(r"\nAuthorID: (\d+)", tmp)[1]  # type: ignore
+        tmp = re.sub(r"\nAuthorID: \d+", "", tmp)
+        tmp = f"{author}\nUP 主 ID： {author_id}\n{tmp}"
+        tmp = (
+            tmp.replace("Length:", "时长：")
+            .replace("Play:", "播放量：")
+            .replace("Favorite:", "收藏量：")
+            .replace("Danmaku:", "弹幕数：")
+            .replace("Comment:", "评论数：")
+            .replace("Match By:", "匹配条件：")
+        )
+        return tmp
+
+    return f"{author}\n{tmp}"

--- a/src/plugins/ELF_RSS2/parsing/routes/danbooru.py
+++ b/src/plugins/ELF_RSS2/parsing/routes/danbooru.py
@@ -27,7 +27,6 @@ async def handle_picture(
     tmp: str,
     tmp_state: Dict[str, Any],
 ) -> str:
-
     # 判断是否开启了只推送标题
     if rss.only_title:
         return ""

--- a/src/plugins/ELF_RSS2/parsing/routes/nga.py
+++ b/src/plugins/ELF_RSS2/parsing/routes/nga.py
@@ -23,7 +23,6 @@ async def handle_check_update(rss: Rss, state: Dict[str, Any]) -> Dict[str, Any]
 
 # 检查更新
 def check_update(db: TinyDB, new: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
-
     # 发送失败 1 次
     to_send_list: List[Dict[str, Any]] = db.search(Query().to_send.exists())
 

--- a/src/plugins/ELF_RSS2/parsing/routes/pixiv.py
+++ b/src/plugins/ELF_RSS2/parsing/routes/pixiv.py
@@ -71,7 +71,7 @@ async def handle_check_update(rss: Rss, state: Dict[str, Any]) -> Dict[str, Any]
 
 
 # 处理图片
-@ParsingBase.append_handler(parsing_type="picture", rex="pixiv")
+@ParsingBase.append_handler(parsing_type="picture", rex="/pixiv/")
 async def handle_picture(
     rss: Rss,
     state: Dict[str, Any],
@@ -147,7 +147,7 @@ async def get_ugoira_video(ugoira_id: str) -> Any:
 
 
 # 处理来源
-@ParsingBase.append_handler(parsing_type="source", rex="pixiv")
+@ParsingBase.append_handler(parsing_type="source", rex="/pixiv/")
 async def handle_source(
     rss: Rss,
     state: Dict[str, Any],
@@ -163,7 +163,7 @@ async def handle_source(
 
 
 # 检查更新
-@ParsingBase.append_before_handler(rex="pixiv/ranking", priority=10)  # type: ignore
+@ParsingBase.append_before_handler(rex="/pixiv/ranking/", priority=10)  # type: ignore
 async def handle_check_update(rss: Rss, state: Dict[str, Any]) -> Dict[str, Any]:
     db = state["tinydb"]
     change_data = check_update(db, state["new_data"])

--- a/src/plugins/ELF_RSS2/parsing/routes/pixiv.py
+++ b/src/plugins/ELF_RSS2/parsing/routes/pixiv.py
@@ -80,7 +80,6 @@ async def handle_picture(
     tmp: str,
     tmp_state: Dict[str, Any],
 ) -> str:
-
     # 判断是否开启了只推送标题
     if rss.only_title:
         return ""
@@ -172,7 +171,6 @@ async def handle_check_update(rss: Rss, state: Dict[str, Any]) -> Dict[str, Any]
 
 # 检查更新
 def check_update(db: TinyDB, new: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
-
     # 发送失败 1 次
     to_send_list: List[Dict[str, Any]] = db.search(Query().to_send.exists())
 

--- a/src/plugins/ELF_RSS2/parsing/routes/south_plus.py
+++ b/src/plugins/ELF_RSS2/parsing/routes/south_plus.py
@@ -38,7 +38,6 @@ async def handle_picture(
     tmp: str,
     tmp_state: Dict[str, Any],
 ) -> str:
-
     # 判断是否开启了只推送标题
     if rss.only_title:
         return ""

--- a/src/plugins/ELF_RSS2/parsing/routes/twitter.py
+++ b/src/plugins/ELF_RSS2/parsing/routes/twitter.py
@@ -24,7 +24,6 @@ async def handle_picture(
     tmp: str,
     tmp_state: Dict[str, Any],
 ) -> str:
-
     # 判断是否开启了只推送标题
     if rss.only_title:
         return ""

--- a/src/plugins/ELF_RSS2/parsing/routes/twitter.py
+++ b/src/plugins/ELF_RSS2/parsing/routes/twitter.py
@@ -15,7 +15,7 @@ from ..utils import get_summary
 
 
 # 处理图片
-@ParsingBase.append_handler(parsing_type="picture", rex="twitter")
+@ParsingBase.append_handler(parsing_type="picture", rex="/twitter/")
 async def handle_picture(
     rss: Rss,
     state: Dict[str, Any],

--- a/src/plugins/ELF_RSS2/parsing/routes/weibo.py
+++ b/src/plugins/ELF_RSS2/parsing/routes/weibo.py
@@ -11,7 +11,7 @@ from ..utils import get_summary
 
 
 # 处理正文 处理网页 tag
-@ParsingBase.append_handler(parsing_type="summary", rex="weibo", priority=10)
+@ParsingBase.append_handler(parsing_type="summary", rex="/weibo/", priority=10)
 async def handle_summary(
     rss: Rss,
     state: Dict[str, Any],
@@ -32,7 +32,7 @@ async def handle_summary(
 
 
 # 处理图片
-@ParsingBase.append_handler(parsing_type="picture", rex="weibo")
+@ParsingBase.append_handler(parsing_type="picture", rex="/weibo/")
 async def handle_picture(
     rss: Rss,
     state: Dict[str, Any],

--- a/src/plugins/ELF_RSS2/parsing/routes/weibo.py
+++ b/src/plugins/ELF_RSS2/parsing/routes/weibo.py
@@ -41,7 +41,6 @@ async def handle_picture(
     tmp: str,
     tmp_state: Dict[str, Any],
 ) -> str:
-
     # 判断是否开启了只推送标题
     if rss.only_title:
         return ""

--- a/src/plugins/ELF_RSS2/parsing/routes/youtube.py
+++ b/src/plugins/ELF_RSS2/parsing/routes/youtube.py
@@ -18,7 +18,6 @@ async def handle_picture(
     tmp: str,
     tmp_state: Dict[str, Any],
 ) -> str:
-
     # 判断是否开启了只推送标题
     if rss.only_title:
         return ""

--- a/src/plugins/ELF_RSS2/parsing/utils.py
+++ b/src/plugins/ELF_RSS2/parsing/utils.py
@@ -17,3 +17,7 @@ def get_summary(item: Dict[str, Any]) -> str:
         item["content"][0]["value"] if item.get("content") else item["summary"]
     )
     return f"<div>{summary}</div>" if re.search("^https?://", summary) else summary
+
+
+def get_author(item: Dict[str, Any]) -> str:
+    return item.get("author", "")


### PR DESCRIPTION
feat(routes/bilibili): 针对 RSSHub 订阅 bilibili 路由，额外返回 UP 主信息，并对 vsearch 路由中的信息进行翻译 (close #391)

refactor(routes): 让路由匹配正则更严格